### PR TITLE
Feature/add vuex typesafe helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "url": "https://github.com/hisasann/typescript-nuxtjs-boilerplate/issues"
   },
   "dependencies": {
+    "@lollipop-onl/vuex-typesafe-helper": "^0.2.6",
     "@nuxt/typescript": "^2.8.0",
     "@nuxtjs/axios": "^5.5.3",
     "@nuxtjs/pwa": "^3.0.0-beta.14",

--- a/src/@types/vuex.d.ts
+++ b/src/@types/vuex.d.ts
@@ -1,0 +1,3 @@
+import { Store as CounterStore } from '@/store/counter'
+
+export type RootStore = CounterStore

--- a/src/pages/example/counter.vue
+++ b/src/pages/example/counter.vue
@@ -2,15 +2,16 @@
 div
   h1.title
     | counter
-  p counter: {{ counter }} {{ this.$store.state.counter.count }}
-  p isOdd: {{ isOdd }} {{ this.$store.getters['counter/isOdd'] }}
   div
-    p Clicked: {{ value }} times
+    p.clicked
+      | Clicked:
+      span.value {{ value }}
+      span times
     p
-      button(@click="onIncrement") +
-      button(@click="onDecrement") -
-      button(@click="onIncrementIfOdd") Increment if odd
-      button(@click="onIncrementAsync") Increment async
+      button.button-size(@click="onIncrement") +
+      button.button-size(@click="onDecrement") -
+      button.button-size(@click="onIncrementIfOdd") Increment if odd
+      button.button-size(@click="onIncrementAsync") Increment async
 </template>
 
 <script lang="ts">
@@ -21,74 +22,53 @@ import { RootStore } from '@/@types/vuex'
 export default class Counter extends Vue {
   $store!: RootStore
 
-  counter: number = 0
-
   /** computed */
-  public get isOdd() {
-    return this.$store.getters['counter/isOdd']
+  public get value() {
+    return this.$store.state.counter.count
   }
 
   /** Nuxt ライフサイクル */
-  public async asyncData({ store }: any) {
-    await console.log('counter/asyncData')
+  public asyncData({ store }: any) {
     const { state } = store as RootStore
     const { count } = state.counter
 
-    return {
-      counter: count + 1
-    }
+    // ...
   }
 
   /** Nuxt ライフサイクル */
-  public async fetch({ store }: any): Promise<void> {
-    await console.log('counter/fetch')
+  public fetch({ store }: any) {
     const { state, commit, dispatch } = store as RootStore
     const { count } = state.counter
 
-    await dispatch('counter/asyncUpdateCount', count + 19)
+    // ...
   }
 
-  /** Vue ライフサイクル */
-  public created() {
-    setTimeout(() => {
-      this.counter = this.increment()
-    }, 3000)
-  }
-
-  /** Vue ライフサイクル */
-  public mounted() {
-    console.log('mounted:', this.$refs)
-
-    setTimeout(async () => {
-      await this.asyncCount(200)
-    }, 5000)
-  }
-
-  public increment() {
+  public onIncrement() {
+    console.log('onIncrement')
     const { state, commit } = this.$store
-    commit('counter/updateCount', state.counter.count + 1)
-
-    // updated counter count
-    console.log('counter/increment', state.counter.count)
-    return state.counter.count
+    commit('counter/increment', 1)
   }
 
-  public async asyncCount(count: number) {
+  public onDecrement() {
+    console.log('onDecrement')
+    const { state, commit } = this.$store
+    commit('counter/decrement', 1)
+  }
+
+  public onIncrementIfOdd() {
+    console.log('onIncrementIfOdd')
+    const { state, getters, commit } = this.$store
+
+    if (getters['counter/isOdd']) {
+      this.onIncrement()
+    }
+  }
+
+  public async onIncrementAsync() {
+    console.log('onIncrementAsync')
     const { state, dispatch } = this.$store
-
-    await dispatch('counter/asyncUpdateCount', state.counter.count + count)
-
-    // updated counter count
-    console.log('counter/asyncCount', state.counter.count)
+    await dispatch('counter/asyncUpdateCount', 1)
   }
-
-  public onIncrement(e) {}
-
-  public onDecrement(e) {}
-
-  public onIncrementIfOdd(e) {}
-
-  public onIncrementAsync(e) {}
 
   public head() {
     return {
@@ -98,4 +78,20 @@ export default class Counter extends Vue {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.clicked {
+  font-size: 1.5em;
+}
+
+.value {
+  color: red;
+  margin: 0 5px 0 5px;
+}
+
+.button-size {
+  font-size: 1.2em;
+  width: 170px;
+  height: 100px;
+  margin: 2px 2px;
+}
+</style>

--- a/src/pages/example/counter.vue
+++ b/src/pages/example/counter.vue
@@ -1,0 +1,101 @@
+<template lang="pug">
+div
+  h1.title
+    | counter
+  p counter: {{ counter }} {{ this.$store.state.counter.count }}
+  p isOdd: {{ isOdd }} {{ this.$store.getters['counter/isOdd'] }}
+  div
+    p Clicked: {{ value }} times
+    p
+      button(@click="onIncrement") +
+      button(@click="onDecrement") -
+      button(@click="onIncrementIfOdd") Increment if odd
+      button(@click="onIncrementAsync") Increment async
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { RootStore } from '@/@types/vuex'
+
+@Component
+export default class Counter extends Vue {
+  $store!: RootStore
+
+  counter: number = 0
+
+  /** computed */
+  public get isOdd() {
+    return this.$store.getters['counter/isOdd']
+  }
+
+  /** Nuxt ライフサイクル */
+  public async asyncData({ store }: any) {
+    await console.log('counter/asyncData')
+    const { state } = store as RootStore
+    const { count } = state.counter
+
+    return {
+      counter: count + 1
+    }
+  }
+
+  /** Nuxt ライフサイクル */
+  public async fetch({ store }: any): Promise<void> {
+    await console.log('counter/fetch')
+    const { state, commit, dispatch } = store as RootStore
+    const { count } = state.counter
+
+    await dispatch('counter/asyncUpdateCount', count + 19)
+  }
+
+  /** Vue ライフサイクル */
+  public created() {
+    setTimeout(() => {
+      this.counter = this.increment()
+    }, 3000)
+  }
+
+  /** Vue ライフサイクル */
+  public mounted() {
+    console.log('mounted:', this.$refs)
+
+    setTimeout(async () => {
+      await this.asyncCount(200)
+    }, 5000)
+  }
+
+  public increment() {
+    const { state, commit } = this.$store
+    commit('counter/updateCount', state.counter.count + 1)
+
+    // updated counter count
+    console.log('counter/increment', state.counter.count)
+    return state.counter.count
+  }
+
+  public async asyncCount(count: number) {
+    const { state, dispatch } = this.$store
+
+    await dispatch('counter/asyncUpdateCount', state.counter.count + count)
+
+    // updated counter count
+    console.log('counter/asyncCount', state.counter.count)
+  }
+
+  public onIncrement(e) {}
+
+  public onDecrement(e) {}
+
+  public onIncrementIfOdd(e) {}
+
+  public onIncrementAsync(e) {}
+
+  public head() {
+    return {
+      title: 'counter'
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/pages/example/index.vue
+++ b/src/pages/example/index.vue
@@ -65,6 +65,8 @@ section
     nuxt-link(to='/example/video', no-prefetch) video
   p
     nuxt-link(to='/example/server-side-set-cookie', no-prefetch) server-side-set-cookie
+  p
+    nuxt-link(to='/example/counter', no-prefetch) counter
 </template>
 
 <script lang="ts">

--- a/src/store/counter.ts
+++ b/src/store/counter.ts
@@ -28,18 +28,18 @@ export type Getters = Convertor<
 >
 
 export const mutations = {
-  updateCount(state: IState, count: number): void {
-    state.count = count
+  increment(state: IState, count: number): void {
+    state.count += count
   },
-  resetCount(state: IState): void {
-    state.count = 0
+  decrement(state: IState, count: number): void {
+    state.count -= count
   }
 }
 export type Mutations = Convertor<
   typeof mutations,
   {
-    'counter/updateCount': 'updateCount'
-    'counter/resetCount': 'resetCount'
+    'counter/increment': 'increment'
+    'counter/decrement': 'decrement'
   }
 >
 
@@ -50,7 +50,7 @@ export const actions = {
     { commit }: Ctx,
     count: number
   ): Promise<void> {
-    await commit('updateCount', count)
+    await commit('increment', count)
   }
 }
 export type Actions = Convertor<

--- a/src/store/counter.ts
+++ b/src/store/counter.ts
@@ -1,0 +1,70 @@
+import Vue from 'vue'
+import {
+  Convertor,
+  DefineActionContext,
+  DefineStoreModule
+} from '@lollipop-onl/vuex-typesafe-helper'
+
+// Only define interface of state
+export interface IState {
+  count: number
+}
+export const state = (): IState => ({
+  count: 0
+})
+
+// Convert to global name
+// It is an error if there is excess or deficiency
+export const getters = {
+  isOdd: (state: IState): number => {
+    return state.count % 2
+  }
+}
+export type Getters = Convertor<
+  typeof getters,
+  {
+    'counter/isOdd': 'isOdd'
+  }
+>
+
+export const mutations = {
+  updateCount(state: IState, count: number): void {
+    state.count = count
+  },
+  resetCount(state: IState): void {
+    state.count = 0
+  }
+}
+export type Mutations = Convertor<
+  typeof mutations,
+  {
+    'counter/updateCount': 'updateCount'
+    'counter/resetCount': 'resetCount'
+  }
+>
+
+export type Ctx = DefineActionContext<IState, typeof getters, typeof mutations>
+export const actions = {
+  async asyncUpdateCount(
+    this: Vue,
+    { commit }: Ctx,
+    count: number
+  ): Promise<void> {
+    await commit('updateCount', count)
+  }
+}
+export type Actions = Convertor<
+  typeof actions,
+  {
+    'counter/asyncUpdateCount': 'asyncUpdateCount'
+  }
+>
+
+// Define store module type
+export type Store = DefineStoreModule<
+  'counter',
+  IState,
+  Getters,
+  Mutations,
+  Actions
+>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1213,6 +1213,14 @@
   dependencies:
     core-js "^2.5.7"
 
+"@lollipop-onl/vuex-typesafe-helper@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@lollipop-onl/vuex-typesafe-helper/-/vuex-typesafe-helper-0.2.6.tgz#a1e21e7acf50869bbc98f77406160191657368b4"
+  integrity sha512-4VpiliSKlyPiVXlCMVtQGg5zxFpkBeB7Oj6kmx1b/Vemlr/I4pQAVuW+S1/j0sRTUW0VYnZ2KvPfqI5lK0yZAw==
+  dependencies:
+    typescript "^3.4.5"
+    vuex "^3.1.1"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -13042,6 +13050,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^3.4.5:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
+  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
 typescript@^3.5.1:
   version "3.5.1"


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - @lollipop-onl/vuex-typesafe-helper を使って Vue.js と Vuex をタイプセーフにする仕組みの導入

[@lollipop-onl/vuex-typesafe-helper - npm](https://www.npmjs.com/package/@lollipop-onl/vuex-typesafe-helper)

- [x] 大本の README にはイシューを投げ済み

[README の getters の type のところはおそらく const が正解かと思います (#1) · Issues · lollipop.onl / vuex-typesafe-helper · GitLab](https://gitlab.com/lollipop.onl/vuex-typesafe-helper/issues/1)